### PR TITLE
Docmument the uselessness of native change events on widgets (#63)

### DIFF
--- a/entries/autocomplete.xml
+++ b/entries/autocomplete.xml
@@ -35,6 +35,7 @@
 		</ul>
 	</longdesc>
 	<note id="functional-css"/>
+	<note id="native-change-warning"/>
 	<added>1.8</added>
 	<options>
 		<option name="appendTo" type="Selector" default="null" example-value='"#someElem"'>

--- a/entries/datepicker.xml
+++ b/entries/datepicker.xml
@@ -48,6 +48,7 @@
 		</ul>
 	</longdesc>
 	<note id="functional-css"/>
+	<note id="native-change-warning"/>
 	<added>1.0</added>
 	<options>
 		<option name="altField" default='""' example-value='"#actualDate"'>

--- a/entries/spinner.xml
+++ b/entries/spinner.xml
@@ -29,6 +29,7 @@
 		</ul>
 	</longdesc>
 	<note id="functional-css"/>
+	<note id="native-change-warning"/>
 	<added>1.9</added>
 	<options>
 		<option name="culture" type="String" default="null" example-value='"fr"'>

--- a/notes.xsl
+++ b/notes.xsl
@@ -4,6 +4,9 @@
 		<xsl:when test="@id = 'functional-css'">
 			This widget requires some functional CSS, otherwise it won't work. If you build a custom theme, use the widget's specific CSS file as a starting point.
 		</xsl:when>
+		<xsl:when test="@id = 'native-change-warning'">
+			This widget manipulates its element's value programmatically, therefore a native change may not be fired when the element's value changes.
+		</xsl:when>
 	</xsl:choose>
 </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
I want to put <code></code> tags around `change` and `value` but I couldn't figure out a way to have that take effect in [notes.xsl](https://github.com/jquery/api.jqueryui.com/blob/master/notes.xsl).
