### PR TITLE
Greedy clarification

### DIFF
--- a/entries/droppable.xml
+++ b/entries/droppable.xml
@@ -31,7 +31,7 @@
 		</option>
 		<xi:include href="../includes/widget-option-disabled.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 		<option name="greedy" type="Boolean" default="false" example-value="true">
-			<desc>By default, when an element is dropped on nested droppables, each droppable will receive the element. However, by setting this option to <code>true</code>, any parent droppables will not receive the element via the callback method. The <code>drop</code> event will still fire on parents, although the <code>e.target</code> will always be the child.</desc>
+			<desc>By default, when an element is dropped on nested droppables, each droppable will receive the element. However, by setting this option to <code>true</code>, any parent droppables will not receive the element. The <code>drop</code> event will still bubble normally, but the <code>event.target</code> can be checked to see which droppable received the draggable element.</desc>
 		</option>
 		<option name="hoverClass" type="String" default="false" example-value='"drop-hover"'>
 			<desc>If specified, the class will be added to the droppable while an acceptable draggable is being hovered over the droppable.</desc>


### PR DESCRIPTION
The description was a little ambiguous. With current documentation, I did not expect parent should have fired `console.log` in this example: http://jsfiddle.net/pe62d/2/ 

I was assuming the event bubble was being stopped within the widget. I'm not too sure my wording of "via the callback method" is the greatest either. Let me know what you think
