### PR TITLE
New restriction on Draggable's handle option

### DIFF
--- a/entries/draggable.xml
+++ b/entries/draggable.xml
@@ -73,7 +73,7 @@
 			<desc>Snaps the dragging helper to a grid, every x and y pixels. The array must be of the form <code>[ x, y ]</code>.</desc>
 		</option>
 		<option name="handle" default="false" example-value='"h2"'>
-			<desc>If specified, restricts dragging from starting unless the mousedown occurs on the specified element(s).</desc>
+			<desc>If specified, restricts dragging from starting unless the mousedown occurs on the specified element(s). Only elements that descend from the draggable element are permitted.</desc>
 			<type name="Selector"/>
 			<type name="Element"/>
 		</option>


### PR DESCRIPTION
cdff72efed495d7a17c551578079619712758793 introduced new restrictions on what can be specified as a draggable's handle. This pull request documents that restriction.
