### PR TITLE
jQuery.widget: Add link to learn articles

### DIFF
--- a/entries/jQuery.widget.xml
+++ b/entries/jQuery.widget.xml
@@ -19,6 +19,8 @@
 
 			<p>jQuery UI contains many widgets that maintain state and therefore have a slightly different usage pattern than typical jQuery plugins. All of jQuery UI's widgets use the same patterns, which is defined by the widget factory. So if you learn how to use one widget, then you'll know how to use all of them.</p>
 
+			<p class="warning">Looking for tutorials about the widget factory? Check out <a href="http://learn.jquery.com/jquery-ui/widget-factory/">the articles on the jQuery Learning Center</a>.</p>
+
 			<p><em>Note: This documentation shows examples using the <a href="/progressbar/">progressbar widget</a> but the syntax is the same for every widget.</em></p>
 
 			<h3>Initialization</h3>


### PR DESCRIPTION
Does this seem good enough or is there more that we should write?

I'm not thrilled about using the `warning` class to get the styling, but we could always just add a `note` class which has the same styling for now just so that we're not abusing classes.
