### PR TITLE
All: Normalize keyboard interaction markup

### DIFF
--- a/entries/accordion.xml
+++ b/entries/accordion.xml
@@ -21,16 +21,16 @@
 
 		<p>When focus is on a header, the following key commands are available:</p>
 		<ul>
-			<li><code>UP</code>/<code>LEFT</code> - Move focus to the previous header. If on first header, moves focus to last header.</li>
-			<li><code>DOWN</code>/<code>RIGHT</code> - Move focus to the next header. If on last header, moves focus to first header.</li>
-			<li><code>HOME</code> - Move focus to the first header.</li>
-			<li><code>END</code> - Move focus to the last header.</li>
-			<li><code>SPACE</code>/<code>ENTER</code> - Activate panel associated with focused header.</li>
+			<li><code>UP</code>/<code>LEFT</code>: Move focus to the previous header. If on first header, moves focus to last header.</li>
+			<li><code>DOWN</code>/<code>RIGHT</code>: Move focus to the next header. If on last header, moves focus to first header.</li>
+			<li><code>HOME</code>: Move focus to the first header.</li>
+			<li><code>END</code>: Move focus to the last header.</li>
+			<li><code>SPACE</code>/<code>ENTER</code>: Activate panel associated with focused header.</li>
 		</ul>
 
 		<p>When focus is in a panel:</p>
 		<ul>
-			<li><code>CTRL</code> + <code>UP</code> - Move focus to associated header.</li>
+			<li><code>CTRL</code> + <code>UP</code>: Move focus to associated header.</li>
 		</ul>
 
 		<xi:include href="../includes/widget-theming.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/autocomplete.xml
+++ b/entries/autocomplete.xml
@@ -15,17 +15,17 @@
 
 		<p>When the menu is open, the following key commands are available:</p>
 		<ul>
-			<li><code>UP</code> - Move focus to the previous item. If on first item, move focus to the input. If on the input, move focus to last item.</li>
-			<li><code>DOWN</code> - Move focus to the next item. If on last item, move focus to the input. If on the input, move focus to the first item.</li>
-			<li><code>ESCAPE</code> - Close the menu.</li>
-			<li><code>ENTER</code> - Select the currently focused item and close the menu.</li>
-			<li><code>TAB</code> - Select the currently focused item, close the menu, and move focus to the next focusable element.</li>
-			<li><code>PAGE UP</code>/<code>PAGE DOWN</code> - Scroll through a page of items (based on height of menu). <em>It's generally a bad idea to display so many items that users need to page.</em></li>
+			<li><code>UP</code>: Move focus to the previous item. If on first item, move focus to the input. If on the input, move focus to last item.</li>
+			<li><code>DOWN</code>: Move focus to the next item. If on last item, move focus to the input. If on the input, move focus to the first item.</li>
+			<li><code>ESCAPE</code>: Close the menu.</li>
+			<li><code>ENTER</code>: Select the currently focused item and close the menu.</li>
+			<li><code>TAB</code>: Select the currently focused item, close the menu, and move focus to the next focusable element.</li>
+			<li><code>PAGE UP</code>/<code>PAGE DOWN</code>: Scroll through a page of items (based on height of menu). <em>It's generally a bad idea to display so many items that users need to page.</em></li>
 		</ul>
 
 		<p>When the menu is closed, the following key commands are available:</p>
 		<ul>
-			<li><code>UP</code>/<code>DOWN</code> - Open the menu, if the <a href="#option-minLength"><code>minLength</code></a> has been met.</li>
+			<li><code>UP</code>/<code>DOWN</code>: Open the menu, if the <a href="#option-minLength"><code>minLength</code></a> has been met.</li>
 		</ul>
 
 		<xi:include href="../includes/widget-theming.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/datepicker.xml
+++ b/entries/datepicker.xml
@@ -10,19 +10,19 @@
 		<h3>Keyboard interaction</h3>
 		<p>While the datepicker is open, the following key commands are available:</p>
 		<ul>
-			<li><code>PAGE UP</code> - Move to the previous month.</li>
-			<li><code>PAGE DOWN</code> - Move to the next month.</li>
-			<li><code>CTRL</code> + <code>PAGE UP</code> - Move to the previous year.</li>
-			<li><code>CTRL</code> + <code>PAGE DOWN</code> - Move to the next year.</li>
-			<li><code>CTRL</code> + <code>HOME</code> - Open the datepicker if closed.</li>
-			<li><code>CTRL</code>/<code>COMMAND</code> + <code>HOME</code> - Move to the current month.</li>
-			<li><code>CTRL</code>/<code>COMMAND</code> + <code>LEFT</code> - Move to the previous day.</li>
-			<li><code>CTRL</code>/<code>COMMAND</code> + <code>RIGHT</code> - Move to the next day.</li>
-			<li><code>CTRL</code>/<code>COMMAND</code> + <code>UP</code> - Move to the previous week.</li>
-			<li><code>CTRL</code>/<code>COMMAND</code> + <code>DOWN</code> - Move the next week.</li>
-			<li><code>ENTER</code> - Select the focused date.</li>
-			<li><code>CTRL</code>/<code>COMMAND</code> + <code>END</code> - Close the datepicker and erase the date.</li>
-			<li><code>ESCAPE</code> - Close the datepicker without selection.</li>
+			<li><code>PAGE UP</code>: Move to the previous month.</li>
+			<li><code>PAGE DOWN</code>: Move to the next month.</li>
+			<li><code>CTRL</code> + <code>PAGE UP</code>: Move to the previous year.</li>
+			<li><code>CTRL</code> + <code>PAGE DOWN</code>: Move to the next year.</li>
+			<li><code>CTRL</code> + <code>HOME</code>: Open the datepicker if closed.</li>
+			<li><code>CTRL</code>/<code>COMMAND</code> + <code>HOME</code>: Move to the current month.</li>
+			<li><code>CTRL</code>/<code>COMMAND</code> + <code>LEFT</code>: Move to the previous day.</li>
+			<li><code>CTRL</code>/<code>COMMAND</code> + <code>RIGHT</code>: Move to the next day.</li>
+			<li><code>CTRL</code>/<code>COMMAND</code> + <code>UP</code>: Move to the previous week.</li>
+			<li><code>CTRL</code>/<code>COMMAND</code> + <code>DOWN</code>: Move the next week.</li>
+			<li><code>ENTER</code>: Select the focused date.</li>
+			<li><code>CTRL</code>/<code>COMMAND</code> + <code>END</code>: Close the datepicker and erase the date.</li>
+			<li><code>ESCAPE</code>: Close the datepicker without selection.</li>
 		</ul>
 
 		<h3 id="utility-functions">Utility functions</h3>

--- a/entries/menu.xml
+++ b/entries/menu.xml
@@ -55,12 +55,12 @@
 		<h3>Keyboard interaction</h3>
 
 		<ul>
-			<li><code>ENTER</code>/<code>SPACE</code> - Invoke the focused menu item's action, which may be opening a submenu.</li>
-			<li><code>UP</code> - Move focus to the previous menu item.</li>
-			<li><code>DOWN</code> - Move focus to the next menu item.</li>
-			<li><code>RIGHT</code> - Open the submenu, if available.</li>
-			<li><code>LEFT</code> - Close the current submenu and move focus to the parent menu item. If not in a submenu, do nothing.</li>
-			<li><code>ESCAPE</code> - Close the current submenu and move focus to the parent menu item. If not in a submenu, do nothing.</li>
+			<li><code>ENTER</code>/<code>SPACE</code>: Invoke the focused menu item's action, which may be opening a submenu.</li>
+			<li><code>UP</code>: Move focus to the previous menu item.</li>
+			<li><code>DOWN</code>: Move focus to the next menu item.</li>
+			<li><code>RIGHT</code>: Open the submenu, if available.</li>
+			<li><code>LEFT</code>: Close the current submenu and move focus to the parent menu item. If not in a submenu, do nothing.</li>
+			<li><code>ESCAPE</code>: Close the current submenu and move focus to the parent menu item. If not in a submenu, do nothing.</li>
 		</ul>
 
 		<p>Typing a letter moves focus to the first item whose title starts with that character. Repeating the same character cycles through matching items. Typing more characters within the one second timer matches those characters.</p>

--- a/entries/selectmenu.xml
+++ b/entries/selectmenu.xml
@@ -11,23 +11,23 @@
 
 		<p>When the menu is open, the following key commands are available:</p>
 		<ul>
-			<li><code>UP</code>/<code>LEFT</code> - Move focus to the previous item.</li>
-			<li><code>DOWN</code>/<code>RIGHT</code> - Move focus to the next item.</li>
-			<li><code>END</code>/<code>PAGE DOWN</code> - Move focus to the last item.</li>
-			<li><code>HOME</code>/<code>PAGE UP</code> - Move focus to the first item.</li>
-			<li><code>ESCAPE</code> - Close the menu.</li>
-			<li><code>ENTER</code>/<code>SPACE</code> - Select the currently focused item and close the menu.</li>
-			<li><code>ALT</code>/<code>OPTION</code> + <code>UP</code>/<code>DOWN</code> - Toggle the visibility of the menu.</li>
+			<li><code>UP</code>/<code>LEFT</code>: Move focus to the previous item.</li>
+			<li><code>DOWN</code>/<code>RIGHT</code>: Move focus to the next item.</li>
+			<li><code>END</code>/<code>PAGE DOWN</code>: Move focus to the last item.</li>
+			<li><code>HOME</code>/<code>PAGE UP</code>: Move focus to the first item.</li>
+			<li><code>ESCAPE</code>: Close the menu.</li>
+			<li><code>ENTER</code>/<code>SPACE</code>: Select the currently focused item and close the menu.</li>
+			<li><code>ALT</code>/<code>OPTION</code> + <code>UP</code>/<code>DOWN</code>: Toggle the visibility of the menu.</li>
 		</ul>
 
 		<p>When the menu is closed, the following key commands are available:</p>
 		<ul>
-			<li><code>UP</code>/<code>LEFT</code> - Select the previous item.</li>
-			<li><code>DOWN</code>/<code>RIGHT</code> - Select the next item.</li>
-			<li><code>END</code>/<code>PAGE DOWN</code> - Select the last item.</li>
-			<li><code>HOME</code>/<code>PAGE UP</code> - Select the first item.</li>
-			<li><code>ALT</code>/<code>OPTION</code> + <code>UP</code>/<code>DOWN</code> - Toggle the visibility of the menu.</li>
-			<li><code>SPACE</code> - Open the menu.</li>
+			<li><code>UP</code>/<code>LEFT</code>: Select the previous item.</li>
+			<li><code>DOWN</code>/<code>RIGHT</code>: Select the next item.</li>
+			<li><code>END</code>/<code>PAGE DOWN</code>: Select the last item.</li>
+			<li><code>HOME</code>/<code>PAGE UP</code>: Select the first item.</li>
+			<li><code>ALT</code>/<code>OPTION</code> + <code>UP</code>/<code>DOWN</code>: Toggle the visibility of the menu.</li>
+			<li><code>SPACE</code>: Open the menu.</li>
 		</ul>
 	</longdesc>
 	<note id="functional-css"/>

--- a/entries/spinner.xml
+++ b/entries/spinner.xml
@@ -12,10 +12,10 @@
 		<h3>Keyboard interaction</h3>
 
 		<ul>
-			<li><code>UP</code> - Increment the value by one step.</li>
-			<li><code>DOWN</code> - Decrement the value by one step.</li>
-			<li><code>PAGE UP</code> - Increment the value by one page.</li>
-			<li><code>PAGE DOWN</code> - Decrement the value by one page.</li>
+			<li><code>UP</code>: Increment the value by one step.</li>
+			<li><code>DOWN</code>: Decrement the value by one step.</li>
+			<li><code>PAGE UP</code>: Increment the value by one page.</li>
+			<li><code>PAGE DOWN</code>: Decrement the value by one page.</li>
 		</ul>
 
 		<p>Focus stays in the text field, even after using the mouse to click one of the spin buttons.</p>

--- a/entries/tabs.xml
+++ b/entries/tabs.xml
@@ -38,21 +38,21 @@
 
 		<p>When focus is on a tab, the following key commands are available:</p>
 		<ul>
-			<li><code>UP</code>/<code>LEFT</code> - Move focus to the previous tab. If on first tab, moves focus to last tab. Activate focused tab after a short delay.</li>
-			<li><code>DOWN</code>/<code>RIGHT</code> - Move focus to the next tab. If on last tab, moves focus to first tab. Activate focused tab after a short delay.</li>
-			<li><code>HOME</code> - Move focus to the first tab. Activate focused tab after a short delay.</li>
-			<li><code>END</code> - Move focus to the last tab. Activate focused tab after a short delay.</li>
-			<li><code>SPACE</code> - Activate panel associated with focused tab.</li>
-			<li><code>ENTER</code> - Activate or toggle panel associated with focused tab.</li>
-			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE UP</code> - Move focus to the previous tab and immediately activate.</li>
-			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE DOWN</code> - Move focus to the next tab and immediately activate.</li>
+			<li><code>UP</code>/<code>LEFT</code>: Move focus to the previous tab. If on first tab, moves focus to last tab. Activate focused tab after a short delay.</li>
+			<li><code>DOWN</code>/<code>RIGHT</code>: Move focus to the next tab. If on last tab, moves focus to first tab. Activate focused tab after a short delay.</li>
+			<li><code>HOME</code>: Move focus to the first tab. Activate focused tab after a short delay.</li>
+			<li><code>END</code>: Move focus to the last tab. Activate focused tab after a short delay.</li>
+			<li><code>SPACE</code>: Activate panel associated with focused tab.</li>
+			<li><code>ENTER</code>: Activate or toggle panel associated with focused tab.</li>
+			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE UP</code>: Move focus to the previous tab and immediately activate.</li>
+			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE DOWN</code>: Move focus to the next tab and immediately activate.</li>
 		</ul>
 
 		<p>When focus is in a panel, the following key commands are available:</p>
 		<ul>
-			<li><code>CTRL</code> + <code>UP</code> - Move focus to associated tab.</li>
-			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE UP</code> - Move focus to the previous tab and immediately activate.</li>
-			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE DOWN</code> - Move focus to the next tab and immediately activate.</li>
+			<li><code>CTRL</code> + <code>UP</code>: Move focus to associated tab.</li>
+			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE UP</code>: Move focus to the previous tab and immediately activate.</li>
+			<li><code>ALT</code>/<code>OPTION</code> + <code>PAGE DOWN</code>: Move focus to the next tab and immediately activate.</li>
 		</ul>
 
 		<xi:include href="../includes/widget-theming.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>


### PR DESCRIPTION
Follow up to discussion in #218. All key commands are now wrapped in code blocks. Key combos have spaces around `+` to ease the mental parsing. There were a mix of colons and dashes between the keys and the description; I chose to normalize to the dashes since they provide additional visual spacing to ease the mental parsing.
