### PR TITLE
Effects: Clean up queue wording since we don't support jQuery <1.7

### DIFF
--- a/includes/animation-signature-options.xml
+++ b/includes/animation-signature-options.xml
@@ -23,7 +23,7 @@
 		<property name="queue" default="true">
 			<type name="Boolean"/>
 			<type name="String"/>
-			<desc>A Boolean indicating whether to place the animation in the effects queue. If false, the animation will begin immediately. <strong>As of jQuery 1.7</strong>, the queue option can also accept a string, in which case the animation is added to the queue represented by that string.</desc>
+			<desc>A Boolean indicating whether to place the animation in the effects queue. If <code>false</code>, the animation will begin immediately. A string can also be provided, in which case the animation is added to the queue represented by that string.</desc>
 		</property>
 	</argument>
 </signature>

--- a/includes/class-animation-argument-options.xml
+++ b/includes/class-animation-argument-options.xml
@@ -22,6 +22,6 @@
 	<property name="queue" default="true">
 		<type name="Boolean"/>
 		<type name="String"/>
-		<desc>A Boolean indicating whether to place the animation in the effects queue. If false, the animation will begin immediately. <strong>As of jQuery 1.7</strong>, the queue option can also accept a string, in which case the animation is added to the queue represented by that string.</desc>
+		<desc>A Boolean indicating whether to place the animation in the effects queue. If <code>false</code>, the animation will begin immediately. A string can also be provided, in which case the animation is added to the queue represented by that string.</desc>
 	</property>
 </argument>


### PR DESCRIPTION
Fixes gh-141

So sad that I couldn't put a description inside each type. That gets me every time. :-(