### PR TITLE
Entries: Use "properties" when referring to individual options

### DIFF
--- a/entries/accordion.xml
+++ b/entries/accordion.xml
@@ -78,7 +78,7 @@
 				<desc>Name of <a href="/easings/">easing</a> to use with default duration.</desc>
 			</type>
 			<type name="Object">
-				<desc><code>easing</code> and <code>duration</code> properties to configure animations.
+				<desc>An object containing <code>easing</code> and <code>duration</code> properties to configure animations.
 					<ul>
 						<li>Can also contain a <code>down</code> property with any of the above options.</li>
 						<li>"Down" animations occur when the panel being activated has a lower index than the currently active panel.</li>

--- a/entries/accordion.xml
+++ b/entries/accordion.xml
@@ -78,7 +78,7 @@
 				<desc>Name of <a href="/easings/">easing</a> to use with default duration.</desc>
 			</type>
 			<type name="Object">
-				<desc>Animation settings with <code>easing</code> and <code>duration</code> properties.
+				<desc><code>easing</code> and <code>duration</code> properties to configure animations.
 					<ul>
 						<li>Can also contain a <code>down</code> property with any of the above options.</li>
 						<li>"Down" animations occur when the panel being activated has a lower index than the currently active panel.</li>

--- a/entries/datepicker.xml
+++ b/entries/datepicker.xml
@@ -27,9 +27,9 @@
 
 		<h3 id="utility-functions">Utility functions</h3>
 
-		<h4 id="utility-setDefaults">$.datepicker.setDefaults( settings )</h4>
-		<p>Change the default settings for all date pickers.</p>
-		<p>Use the <a href="#method-option"><code>option()</code></a> method to change settings for individual instances.</p>
+		<h4 id="utility-setDefaults">$.datepicker.setDefaults( options )</h4>
+		<p>Change the default options for all date pickers.</p>
+		<p>Use the <a href="#method-option"><code>option()</code></a> method to change options for individual instances.</p>
 		<div>
 			<strong>Code examples:</strong>
 			<p>Set all date pickers to open on focus or a click on an icon.</p>
@@ -47,7 +47,7 @@
 			</code></pre>
 		</div>
 
-		<h4 id="utility-formatDate">$.datepicker.formatDate( format, date, settings )</h4>
+		<h4 id="utility-formatDate">$.datepicker.formatDate( format, date, options )</h4>
 		<p>Format a date into a string value with a specified format.</p>
 		<p>The format can be combinations of the following:</p>
 		<ul>
@@ -101,7 +101,7 @@
 			</code></pre>
 		</div>
 
-		<h4 id="utility-parseDate">$.datepicker.parseDate( format, value, settings )</h4>
+		<h4 id="utility-parseDate">$.datepicker.parseDate( format, value, options )</h4>
 		<p>Extract a date from a string value with a specified format.</p>
 		<p>The format can be combinations of the following:</p>
 		<ul>
@@ -175,7 +175,7 @@
 		</div>
 
 		<h3>Localization</h3>
-		<p>Datepicker provides support for localizing its content to cater for different languages and date formats. Each localization is contained within its own file with the language code appended to the name, e.g., <code>jquery.ui.datepicker-fr.js</code> for French. The desired localization file should be included after the main datepicker code. Each localization file adds its settings to the set of available localizations and automatically applies them as defaults for all instances. Localization files can be found at <a href="https://github.com/jquery/jquery-ui/tree/master/ui/i18n">https://github.com/jquery/jquery-ui/tree/master/ui/i18n</a>.</p>
+		<p>Datepicker provides support for localizing its content to cater for different languages and date formats. Each localization is contained within its own file with the language code appended to the name, e.g., <code>jquery.ui.datepicker-fr.js</code> for French. The desired localization file should be included after the main datepicker code. Each localization file adds its options to the set of available localizations and automatically applies them as defaults for all instances. Localization files can be found at <a href="https://github.com/jquery/jquery-ui/tree/master/ui/i18n">https://github.com/jquery/jquery-ui/tree/master/ui/i18n</a>.</p>
 		<p>The <code>$.datepicker.regional</code> attribute holds an array of localizations, indexed by language code, with <code>""</code> referring to the default (English). Each entry is an object with the following attributes: <code>closeText</code>, <code>prevText</code>, <code>nextText</code>, <code>currentText</code>, <code>monthNames</code>, <code>monthNamesShort</code>, <code>dayNames</code>, <code>dayNamesShort</code>, <code>dayNamesMin</code>, <code>weekHeader</code>, <code>dateFormat</code>, <code>firstDay</code>, <code>isRTL</code>, <code>showMonthAfterYear</code>, and <code>yearSuffix</code>.</p>
 		<p>You can restore the default localizations with:</p>
 		<code>$.datepicker.setDefaults( $.datepicker.regional[ "" ] );</code>
@@ -405,7 +405,7 @@
 			<desc>When the datepicker should appear. The datepicker can appear when the field receives focus (<code>"focus"</code>), when a button is clicked (<code>"button"</code>), or when either event occurs (<code>"both"</code>).</desc>
 		</option>
 		<option name="showOptions" type="Object" default="{}" example-value='{ direction: "up" }'>
-			<desc>If using one of the jQuery UI effects for the <a href="#option-showAnim"><code>showAnim</code></a> option, you can provide additional settings for that animation via this option.</desc>
+			<desc>If using one of the jQuery UI effects for the <a href="#option-showAnim"><code>showAnim</code></a> option, you can provide additional properties for that animation using this option.</desc>
 		</option>
 		<option name="showOtherMonths" type="Boolean" default="false" example-value="true">
 			<desc>Whether to display dates in other months (non-selectable) at the start or end of the current month. To make these days selectable use the <a href="#option-selectOtherMonths"><code>selectOtherMonths</code></a> option.</desc>
@@ -471,8 +471,8 @@
 			<argument name="onSelect" type="Function" optional="true">
 				<desc>A callback function when a date is selected. The function receives the date text and date picker instance as parameters.</desc>
 			</argument>
-			<argument name="settings" type="Options" optional="true">
-				<desc>The new settings for the date picker.</desc>
+			<argument name="options" type="Options" optional="true">
+				<desc>The new options for the date picker.</desc>
 			</argument>
 			<argument name="pos" type="Number[2] or MouseEvent" optional="true">
 				<desc>The position of the top/left of the dialog as <code>[x, y]</code> or a <code>MouseEvent</code> that contains the coordinates. If not specified the dialog is centered on the screen.</desc>

--- a/entries/effect.xml
+++ b/entries/effect.xml
@@ -10,7 +10,7 @@
 			<desc>A string indicating which <a href="/category/effects/">effect</a> to use for the transition.</desc>
 		</argument>
 		<argument name="options" type="Object" optional="true">
-			<desc>Effect-specific settings and <a href="/easings/">easing</a>.</desc>
+			<desc>Effect-specific properties and <a href="/easings/">easing</a>.</desc>
 		</argument>
 		<xi:include href="../includes/animation-argument-duration.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 		<xi:include href="../includes/animation-argument-complete.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/hide.xml
+++ b/entries/hide.xml
@@ -10,7 +10,7 @@
 			<desc>A string indicating which <a href="/category/effects/">effect</a> to use for the transition.</desc>
 		</argument>
 		<argument name="options" type="Object" optional="true">
-			<desc>Effect-specific settings and <a href="/easings/">easing</a>.</desc>
+			<desc>Effect-specific properties and <a href="/easings/">easing</a>.</desc>
 		</argument>
 		<xi:include href="../includes/animation-argument-duration.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 		<xi:include href="../includes/animation-argument-complete.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/jQuery.widget.xml
+++ b/entries/jQuery.widget.xml
@@ -43,7 +43,7 @@
 
 			<p>We can pass as many or as few options as we want during initialization. Any options that we don't pass will just use their default values.</p>
 
-			<p>You can pass multiple options arguments. Those arguments will be merged into one object (similar to <a href="//api.jquery.com/jQuery.extend/"><code>$.extend( true, target, object1, objectN )</code></a>). This is useful for sharing options between instances, while overriding some settings for each one:</p>
+			<p>You can pass multiple options arguments. Those arguments will be merged into one object (similar to <a href="//api.jquery.com/jQuery.extend/"><code>$.extend( true, target, object1, objectN )</code></a>). This is useful for sharing options between instances, while overriding some properties for each one:</p>
 
 			<pre><code>
 				var options = { modal: true, show: "slow" };
@@ -508,7 +508,7 @@ this._on( this.element, {
 					<desc>The element(s) to show.</desc>
 				</argument>
 				<argument name="option" type="Object">
-					<desc>The settings defining how to show the element.</desc>
+					<desc>The properties defining how to show the element.</desc>
 				</argument>
 				<argument name="callback" type="Function" optional="true">
 					<desc>Callback to invoke after the element has been fully shown.</desc>
@@ -532,7 +532,7 @@ this._show( this.element, this.options.show, function() {
 					<desc>The element(s) to hide.</desc>
 				</argument>
 				<argument name="option" type="Object">
-					<desc>The settings defining how to hide the element.</desc>
+					<desc>The properties defining how to hide the element.</desc>
 				</argument>
 				<argument name="callback" type="Function" optional="true">
 					<desc>Callback to invoke after the element has been fully hidden.</desc>

--- a/entries/show.xml
+++ b/entries/show.xml
@@ -10,7 +10,7 @@
 			<desc>A string indicating which <a href="/category/effects/">effect</a> to use for the transition.</desc>
 		</argument>
 		<argument name="options" type="Object" optional="true">
-			<desc>Effect-specific settings and <a href="/easings/">easing</a>.</desc>
+			<desc>Effect-specific properties and <a href="/easings/">easing</a>.</desc>
 		</argument>
 		<xi:include href="../includes/animation-argument-duration.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 		<xi:include href="../includes/animation-argument-complete.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/tabs.xml
+++ b/entries/tabs.xml
@@ -172,7 +172,7 @@
 		<event name="beforeLoad">
 			<desc>
 				<p>Triggered when a remote tab is about to be loaded, after the <a href="#event-beforeActivate"><code>beforeActivate</code></a> event. Can be canceled to prevent the tab panel from loading content; though the panel will still be activated. This event is triggered just before the Ajax request is made, so modifications can be made to <code>ui.jqXHR</code> and <code>ui.ajaxSettings</code>.</p>
-				<p><em>Note: Although <code>ui.ajaxSettings</code> is provided and can be modified, some of these settings have already been processed by jQuery. For example, <a href="//api.jquery.com/jQuery.ajaxPrefilter/">prefilters</a> have been applied, <code>data</code> has been processed, and <code>type</code> has been determined. The <code>beforeLoad</code> event occurs at the same time, and therefore has the same restrictions, as the <code>beforeSend</code> callback from <a href="//api.jquery.com/jQuery.ajax/"><code>jQuery.ajax()</code></a>.</em></p>
+				<p><em>Note: Although <code>ui.ajaxSettings</code> is provided and can be modified, some of these properties have already been processed by jQuery. For example, <a href="//api.jquery.com/jQuery.ajaxPrefilter/">prefilters</a> have been applied, <code>data</code> has been processed, and <code>type</code> has been determined. The <code>beforeLoad</code> event occurs at the same time, and therefore has the same restrictions, as the <code>beforeSend</code> callback from <a href="//api.jquery.com/jQuery.ajax/"><code>jQuery.ajax()</code></a>.</em></p>
 			</desc>
 			<argument name="event" type="Event"/>
 			<argument name="ui" type="Object">
@@ -186,7 +186,7 @@
 					<desc>The <code>jqXHR</code> object that is requesting the content.</desc>
 				</property>
 				<property name="ajaxSettings" type="Object">
-					<desc>The settings that will be used by <a href="//api.jquery.com/jQuery.ajax/"><code>jQuery.ajax</code></a> to request the content.</desc>
+					<desc>The properties that will be used by <a href="//api.jquery.com/jQuery.ajax/"><code>jQuery.ajax</code></a> to request the content.</desc>
 				</property>
 			</argument>
 		</event>

--- a/entries/toggle.xml
+++ b/entries/toggle.xml
@@ -10,7 +10,7 @@
 			<desc>A string indicating which <a href="/category/effects/">effect</a> to use for the transition.</desc>
 		</argument>
 		<argument name="options" type="Object" optional="true">
-			<desc>Effect-specific settings and <a href="/easings/">easing</a>.</desc>
+			<desc>Effect-specific properties and <a href="/easings/">easing</a>.</desc>
 		</argument>
 		<xi:include href="../includes/animation-argument-duration.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 		<xi:include href="../includes/animation-argument-complete.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>


### PR DESCRIPTION
Removes some ambiguity since we also "setting" as a verb.

Fixes #247 