### PR TITLE
Effects: Mark transfer-effect deprecated, document .transfer()

### DIFF
--- a/entries/transfer.xml
+++ b/entries/transfer.xml
@@ -14,8 +14,10 @@
 			<property name="className" type="String" default="null">
 				<desc>A class to add to the transfer element, in addition to <code>ui-effects-transfer</code>.</desc>
 			</property>
-			<property name="duration" type="Number" default="400">
-				<desc>The strings <code>"fast"</code> and <code>"slow"</code> can be supplied to indicate durations of 200 and 600 milliseconds, respectively.</desc>
+			<property name="duration" default="400">
+				<desc>A string or number determining how long the animation will run. The strings <code>"fast"</code> and <code>"slow"</code> can be supplied to indicate durations of 200 and 600 milliseconds, respectively. The number type indicates the duration in milliseconds.</desc>
+				<type name="Number"/>
+				<type name="String"/>
 			</property>
 			<property name="easing" type="String" default="swing">
 				<desc>A string indicating which <a href="/easings/">easing</a> function to use for the transition.</desc>

--- a/entries/transfer.xml
+++ b/entries/transfer.xml
@@ -15,15 +15,13 @@
 				<desc>A class to add to the transfer element, in addition to <code>ui-effects-transfer</code>.</desc>
 			</property>
 			<property name="duration" type="Number" default="400">
-				<desc>How long the animation runs.</desc>
+				<desc>The strings <code>"fast"</code> and <code>"slow"</code> can be supplied to indicate durations of 200 and 600 milliseconds, respectively.</desc>
 			</property>
 			<property name="easing" type="String" default="swing">
-				<desc>The easing to use for the animation.</desc>
+				<desc>A string indicating which <a href="/easings/">easing</a> function to use for the transition.</desc>
 			</property>
 		</argument>
-		<argument name="done" type="Callback">
-			<desc>A function to invoke once the animation completes.</desc>
-		</argument>
+		<xi:include href="../includes/animation-argument-complete.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 	</signature>
 	<example>
 		<height>150</height>

--- a/entries/transfer.xml
+++ b/entries/transfer.xml
@@ -1,38 +1,46 @@
 <?xml version="1.0"?>
-<entry name="transfer" type="effect" deprecated="1.12">
-	<title>Transfer Effect</title>
+<entry name="transfer" type="method" return="jQuery">
+	<title>.transfer()</title>
 	<desc>Transfers the outline of an element to another element</desc>
 	<longdesc>
 		<p>Very useful when trying to visualize interaction between two elements.</p>
 		<p>The transfer element itself has the class <code>ui-effects-transfer</code>, and needs to be styled by you, for example by adding a background or border.</p>
-		<p class="warning">This effect is deprecated, replaced by the <a href="/transfer/">.transfer()</a> method.</p>
 	</longdesc>
-	<arguments>
-		<argument name="className" type="String">
-			<desc>argumental class name the transfer element will receive.</desc>
+	<signature>
+		<argument name="options" type="Object">
+			<property name="to" type="Selector">
+				<desc>The target of the transfer effect.</desc>
+			</property>
+			<property name="className" type="String" default="null">
+				<desc>A class to add to the transfer element, in addition to <code>ui-effects-transfer</code>.</desc>
+			</property>
+			<property name="duration" type="Number" default="400">
+				<desc>How long the animation runs.</desc>
+			</property>
+			<property name="easing" type="String" default="swing">
+				<desc>The easing to use for the animation.</desc>
+			</property>
 		</argument>
-		<argument name="to" type="String">
-			<desc>jQuery selector, the element to transfer to.</desc>
+		<argument name="done" type="Callback">
+			<desc>A function to invoke once the animation completes.</desc>
 		</argument>
-	</arguments>
+	</signature>
 	<example>
 		<height>150</height>
 		<desc>Clicking on the green element transfers to the other.</desc>
 		<css><![CDATA[
-	div.green {
+	.green {
 		width: 100px;
 		height: 80px;
 		background: green;
 		border: 1px solid black;
-		position: relative;
 	}
-	div.red {
+	.red {
 		margin-top: 10px;
 		width: 50px;
 		height: 30px;
 		background: red;
 		border: 1px solid black;
-		position: relative;
 	}
 	.ui-effects-transfer {
 		border: 1px dotted black;
@@ -41,7 +49,10 @@
 		<code><![CDATA[
 $( "div" ).click(function() {
 	var i = 1 - $( "div" ).index( this );
-	$( this ).effect( "transfer", { to: $( "div" ).eq( i ) }, 1000 );
+	$( this ).transfer( {
+		to: $( "div" ).eq( i ),
+		duration: 1000
+	} );
 });
 ]]></code>
 		<html><![CDATA[
@@ -50,4 +61,5 @@ $( "div" ).click(function() {
 ]]></html>
 	</example>
 	<category slug="effects"/>
+	<category slug="effects-core"/>
 </entry>


### PR DESCRIPTION
Ref gh-242

First commit to document the effects rewrite, more to come.