### PR TITLE
Build: import redirects from the infrastructure repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "grunt": "0.4.5",
-    "grunt-jquery-content": "2.2.0"
+    "grunt-jquery-content": "2.3.0"
   }
 }

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,3 @@
+{
+	"/api/": "/resources/api.xml"
+}


### PR DESCRIPTION
Possible as of grunt-jquery-content [2.3.0](https://github.com/jquery/grunt-jquery-content/commit/81579ec2e3db6327969f0f7cfcaab2b6afedec11), and now we want to port all redirects over from the nginx configs to the repos.

This site only had one redirect in the nginx configs: https://github.com/jquery/infrastructure/blob/puppet-master/modules/jquery/manifests/wp/jqueryui.pp#L20-22.

@gnarf Can you review this? Thanks.