### PR TITLE
All: Don't use jQuery positional selectors in examples

### DIFF
--- a/entries/autocomplete.xml
+++ b/entries/autocomplete.xml
@@ -228,7 +228,7 @@ _renderMenu: function( ul, items ) {
 	$.each( items, function( index, item ) {
 		that._renderItemData( ul, item );
 	});
-	$( ul ).find( "li:odd" ).addClass( "odd" );
+	$( ul ).find( "li" ).odd().addClass( "odd" );
 }
 ]]></code>
 			</example>

--- a/entries/menu.xml
+++ b/entries/menu.xml
@@ -193,7 +193,7 @@
 				<desc>What triggered the menu to expand.</desc>
 			</argument>
 		</method>
-		<method name="focus" example-params='null, menu.find( ".ui-menu-item:last" )'>
+		<method name="focus" example-params='null, menu.find( ".ui-menu-item" ).last()'>
 			<desc>
 				Activates the given menu item and triggers the menu's <a href="#event-focus"><code>focus</code></a> event. Opens the menu item's sub-menu, if one exists.
 			</desc>

--- a/entries/selectmenu.xml
+++ b/entries/selectmenu.xml
@@ -248,7 +248,7 @@ _renderMenu: function( ul, items ) {
 	$.each( items, function( index, item ) {
 		that._renderItemData( ul, item );
 	});
-	$( ul ).find( "li:odd" ).addClass( "odd" );
+	$( ul ).find( "li" ).odd().addClass( "odd" );
 }
 ]]></code>
 			</example>


### PR DESCRIPTION
Positional selectors are deprecated and will be removed in jQuery 4.0.

See https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/