### PR TITLE
Draggable:Resizable:Selectable:Sortable: Allow using a Function as cancel …

### DIFF
--- a/entries/draggable.xml
+++ b/entries/draggable.xml
@@ -45,8 +45,14 @@
 		<option name="axis" type="String" default="false" example-value='"x"'>
 			<desc>Constrains dragging to either the horizontal (x) or vertical (y) axis. Possible values: <code>"x"</code>, <code>"y"</code>.</desc>
 		</option>
-		<option name="cancel" type="Selector" default='"input,textarea,button,select,option"' example-value='".title"'>
+		<option name="cancel" default='"input,textarea,button,select,option"' example-value='".title"'>
 			<desc>Prevents dragging from starting on specified elements.</desc>
+			<type name="Selector">
+				<desc>A selector specifying elements for which dragging is canceled.</desc>
+			</type>
+			<type name="Function">
+				<desc>A function that can return true to cancel dragging. The function receives the event object.</desc>
+			</type>
 		</option>
 		<option name="classes" type="Object" default="{}">
 			<xi:include href="../includes/classes-option-desc.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/mouse.xml
+++ b/entries/mouse.xml
@@ -11,8 +11,14 @@
 		</ul>
 	</longdesc>
 	<options>
-		<option name="cancel" type="Selector" default='"input,textarea,button,select,option"' example-value='".title"'>
+		<option name="cancel" default='"input,textarea,button,select,option"' example-value='".title"'>
 			<desc>Prevents interactions from starting on specified elements.</desc>
+			<type name="Selector">
+				<desc>A selector specifying elements for which interactions are canceled.</desc>
+			</type>
+			<type name="Function">
+				<desc>A function that can return true to cancel interactions. The function receives the event object.</desc>
+			</type>
 		</option>
 		<option name="delay" type="Number" default="0" example-value="300">
 			<deprecated>1.12</deprecated>

--- a/entries/resizable.xml
+++ b/entries/resizable.xml
@@ -57,8 +57,14 @@
 		<option name="autoHide" type="Boolean" default="false" example-value='true'>
 			<desc>Whether the handles should hide when the user is not hovering over the element.</desc>
 		</option>
-		<option name="cancel" type="Selector" default='"input,textarea,button,select,option"' example-value='".cancel"'>
+		<option name="cancel" default='"input,textarea,button,select,option"' example-value='".cancel"'>
 			<desc>Prevents resizing from starting on specified elements.</desc>
+			<type name="Selector">
+				<desc>A selector specifying elements for which resizing is canceled.</desc>
+			</type>
+			<type name="Function">
+				<desc>A function that can return true to cancel resizing. The function receives the event object.</desc>
+			</type>
 		</option>
 		<option name="containment" default="false" example-value='"parent"'>
 			<desc>Constrains resizing to within the bounds of the specified element or region.</desc>

--- a/entries/selectable.xml
+++ b/entries/selectable.xml
@@ -33,8 +33,14 @@
 		<option name="autoRefresh" type="Boolean" default="true" example-value='false'>
 			<desc>This determines whether to refresh (recalculate) the position and size of each selectee at the beginning of each select operation. If you have many items, you may want to set this to false and call the <a href="#method-refresh"><code>refresh()</code></a> method manually.</desc>
 		</option>
-		<option name="cancel" type="Selector" default='"input,textarea,button,select,option"' example-value='"a,.cancel"'>
+		<option name="cancel" default='"input,textarea,button,select,option"' example-value='"a,.cancel"'>
 			<desc>Prevents selecting if you start on elements matching the selector.</desc>
+			<type name="Selector">
+				<desc>A selector specifying elements for which selecting is canceled.</desc>
+			</type>
+			<type name="Function">
+				<desc>A function that can return true to cancel selecting. The function receives the event object.</desc>
+			</type>
 		</option>
 		<option name="classes" type="Object" default="{}">
 			<xi:include href="../includes/classes-option-desc.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>

--- a/entries/sortable.xml
+++ b/entries/sortable.xml
@@ -46,8 +46,14 @@
 		<option name="axis" type="String" default='false' example-value='"x"'>
 			<desc>If defined, the items can be dragged only horizontally or vertically. Possible values: <code>"x"</code>, <code>"y"</code>.</desc>
 		</option>
-		<option name="cancel" type="Selector" default='"input,textarea,button,select,option"' example-value='"a,button"'>
+		<option name="cancel" default='"input,textarea,button,select,option"' example-value='"a,button"'>
 			<desc>Prevents sorting if you start on elements matching the selector.</desc>
+			<type name="Selector">
+				<desc>A selector specifying elements for which sorting is canceled.</desc>
+			</type>
+			<type name="Function">
+				<desc>A function that can return true to cancel sorting. The function receives the event object.</desc>
+			</type>
 		</option>
 		<option name="classes" type="Object" default="{}">
 			<xi:include href="../includes/classes-option-desc.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>


### PR DESCRIPTION
…option instead of a Selector. This is particularly useful when using Sortable on nested lists.

API update corresponding to https://github.com/jquery/jquery-ui/pull/2324